### PR TITLE
Fix HP handling across difficulty modes

### DIFF
--- a/js/menu.js
+++ b/js/menu.js
@@ -19,7 +19,21 @@ startBtn.addEventListener("click", () => {
   menu.classList.add("hidden");
   game.classList.remove("hidden");
   // 遊戲初始化
-  window.gameState.hp = 4;
+  let maxHp;
+  switch (window.gameState.difficulty) {
+    case "easy":
+      maxHp = 10;
+      break;
+    case "normal":
+      maxHp = 5;
+      break;
+    case "hard":
+      maxHp = 2;
+      break;
+    default:
+      maxHp = 4;
+  }
+  window.gameState.hp = maxHp;
   window.gameState.score = 0;
   window.gameState.playing = true;
   window.gameState.startTime = Date.now();

--- a/js/reduce_hp.js
+++ b/js/reduce_hp.js
@@ -1,5 +1,6 @@
 function reduceHealth() {
   window.gameState.hp--;
+  let maxHp;
   switch (window.gameState.difficulty) {
     case "easy":
       maxHp = 10;
@@ -8,10 +9,12 @@ function reduceHealth() {
       maxHp = 5;
       break;
     case "hard":
-      maxHp = 1;
+      maxHp = 2;
       break;
+    default:
+      maxHp = 4;
   }
-  hpBar.style.width = (window.gameState.hp / 4) * 100 + "%";
+  hpBar.style.width = (window.gameState.hp / maxHp) * 100 + "%";
   if (window.gameState.hp <= 0) {
     handleGameOver();
   }

--- a/js/reset_game.js
+++ b/js/reset_game.js
@@ -8,7 +8,7 @@ function resetGameData() {
       window.gameState.hp = 5;
       break;
     case "hard":
-      window.gameState.hp = 1;
+      window.gameState.hp = 2;
       break;
     default:
       window.gameState.hp = 5;


### PR DESCRIPTION
## Summary
- calculate max HP based on current difficulty when starting a game
- use consistent max HP when HP is reduced
- reset game data with the correct max HP

## Testing
- `pytest`
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683ff668a7108323afd325badbc3932b